### PR TITLE
The xpaths returned when diffing with namespaces were invalid xpaths

### DIFF
--- a/src/xmldiff/parser.py
+++ b/src/xmldiff/parser.py
@@ -70,13 +70,13 @@ class SaxHandler(ContentHandler):
 
     def _buildTag(self, ns_name_tuple):
         ns_uri, local_name = ns_name_tuple
-        if ns_uri:
-            el_tag = "{%s}%s" % ns_name_tuple
-        elif self._default_ns:
-            el_tag = "{%s}%s" % (self._default_ns, local_name)
-        else:
-            el_tag = local_name
-        return el_tag
+
+        if ns_uri and ns_uri != self._default_ns:
+            ns_name = [x[0] for x in self._ns_mapping.items()
+                       if ns_uri in x[1]][0]
+            return "%s:%s" % (ns_name, local_name)
+
+        return local_name
 
     ## method of the ContentHandler interface #################################
     def startElementNS(self, name, qname, attributes):

--- a/tests/data/parse/default_ns.xml
+++ b/tests/data/parse/default_ns.xml
@@ -1,0 +1,10 @@
+<section xmlns="urn:corp:sec">
+    <sectionInfo>
+        <secID>S001</secID>
+        <name>Sales</name>
+    </sectionInfo>
+    <sectionInfo secID="S002" name="Development">
+    </sectionInfo>
+    <sectionInfo secID="S003" name="Gardening">
+    </sectionInfo>
+</section>

--- a/tests/data/test10_ns_result
+++ b/tests/data/test10_ns_result
@@ -38,7 +38,7 @@ Insert mixed element with text
 [rename, /Tests[1]/Test[7]/Eight[1], Six]
 [move-first, /Tests[1]/Test[6]/@type, /Tests[1]/Test[8]]
 [move-first, /Tests[1]/Test[7]/@type, /Tests[1]/Test[9]]
-[update, /Tests[1]/Test[3]/{urn:test_ns}Four[1]/text()[1], This WAS the fourth sentence.]
+[update, /Tests[1]/Test[3]/tns:Four[1]/text()[1], This WAS the fourth sentence.]
 [update, /Tests[1]/Test[6]/Five[1]/text()[1], This is the]
 [insert-after, /Tests[1]/Test[6]/Five[1]/text()[1],
 <new/>
@@ -57,7 +57,7 @@ and improved
 [append-first, /Tests[1]/Test[10]/Nine[1]/b[1],
 (changed)
 ]
-[remove, /Tests[1]/{urn:test_ns}Test[1]/Two[2]]
+[remove, /Tests[1]/tns:Test[1]/Two[2]]
 [remove, /Tests[1]/Test[2]/Three[1]]
 [remove, /Tests[1]/Test[4]]
 [remove, /Tests[1]/Test[4]]

--- a/tests/data/test11_ns_result
+++ b/tests/data/test11_ns_result
@@ -1,1 +1,1 @@
-[update, /Tests[1]/Test[1]/Nine[1]/b[1]/@{urn:test_ns}name, NineNameChanged]
+[update, /Tests[1]/Test[1]/Nine[1]/b[1]/@tns:name, NineNameChanged]


### PR DESCRIPTION
"{uri:something}tag" is not valid xpaths, instead it now uses the namespace id, "something:tag"