### PR TITLE
The second part of the attribute renaming had the wrong xpath

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ CHANGES
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- When moving attributes the secondary rename action xpath was
+  '//LogilabXmldiffTmpAttr<attrib>' which is a tag specification.
+  Changed this to '//@LogilabXmldiffTmpAttr<attrib>', so an attribute
+  is specified.
 
 
 1.1.0 (2018-06-15)

--- a/src/xmldiff/fmes.py
+++ b/src/xmldiff/fmes.py
@@ -100,7 +100,7 @@ class FmesCorrector:
         self._fmes_step2(tree1, tree2)
         # step 3: rename tmp attributes
         for tmp_name, real_name in self._tmp_attrs_dict.items():
-            self.add_action(['rename', '//%s' % tmp_name, real_name])
+            self.add_action(['rename', '//@%s' % tmp_name, real_name])
         # free mapping ref in C extensions
         fmes_end()
         self._formatter.end()

--- a/tests/data/test08_result
+++ b/tests/data/test08_result
@@ -63,4 +63,4 @@ and improved
 [remove, /Tests[1]/Test[5]/Five[1]/b[1]]
 [remove, /Tests[1]/Test[6]/Six[1]/b[1]]
 [remove, /Tests[1]/Test[9]/Nine[1]/b[2]]
-[rename, //LogilabXmldiffTmpAttrtype, type]
+[rename, //@LogilabXmldiffTmpAttrtype, type]

--- a/tests/data/test10_ns_result
+++ b/tests/data/test10_ns_result
@@ -65,4 +65,4 @@ and improved
 [remove, /Tests[1]/Test[5]/Six[1]/b[1]]
 [remove, /Tests[1]/Test[8]/Nine[1]/b[1]/text()[2]]
 [remove, /Tests[1]/Test[8]/Nine[1]/b[1]/LogilabXMLDIFFFAKETag[1]]
-[rename, //LogilabXmldiffTmpAttrtype, type]
+[rename, //@LogilabXmldiffTmpAttrtype, type]


### PR DESCRIPTION
When moving attributes the secondary rename action xpath was
'//LogilabXmldiffTmpAttr<attrib>' which is a tag specification.
Changed this to '//@LogilabXmldiffTmpAttr<attrib>', so an attribute
is specified.