### PR TITLE
Once again fix the namespace handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ CHANGES
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- When I fixed the xpath namespace handling I also changed the tag names to
+  an xpath syntax. This was unhelpful, so I changed that back. To solve this
+  I have had to extend the return format from the parser and ass a N_NSPREFIX
+  that contains the prefix. This is used by the differ to return correct
+  xpaths without changing the tags.
 
 
 1.1.1 (2018-06-20)

--- a/src/xmldiff/fmes.py
+++ b/src/xmldiff/fmes.py
@@ -384,7 +384,7 @@ class FmesCorrector:
         return attr_name
 
     FAKE_TAG = [NT_NODE, 'LogilabXMLDIFFFAKETag', 'LogilabXMLDIFFFAKETag',
-                [], None, 0, 0, True, False]
+                [], None, 0, 0, None, True, False]
 
     def _before_insert_text(self, parent, new_text, k):
         """ check if a text node that will be remove has two sibbling text

--- a/src/xmldiff/objects.py
+++ b/src/xmldiff/objects.py
@@ -41,7 +41,8 @@ N_CHILDS = 3  # nodes's childs list
 N_PARENT = 4  # node's parent
 N_ISSUE = 5  # node's total issue number
 N_XNUM = 6  # to compute node's xpath
-NSIZE = 7  # number of items in a list which represent a node
+N_NSPREFIX = 7  # node's namespace prefix (if any)
+NSIZE = 8  # number of items in a list which represent a node
 
 # NODE TYPES
 # NT_SYST = 0 # SYSTEM node (added by parser) /!\ deprecated
@@ -120,14 +121,26 @@ def caract(node):
 
 def f_xpath(node, x=''):
     """ compute node's xpath """
-    if node[N_NAME] != '/':
+    name = node[N_NAME]
+    if '{' in name:
+        # We have a namespace
+        pre, rest = name.split('{', 1)
+        uri, local_name = rest.split('}', 1)
+        prefix = node[N_NSPREFIX]
+        if prefix is None:
+            # Default namespace
+            name = pre + local_name
+        else:
+            name = '%s%s:%s' % (pre, prefix, local_name)
+
+    if name != '/':
         if node[N_TYPE] == NT_ATTN:
             return f_xpath(node[N_PARENT],
-                           '/%s' % node[N_NAME][:len(node[N_NAME]) - 4])
+                           '/%s' % name[:len(name) - 4])
         if node[N_TYPE] == NT_ATTV:
-            return f_xpath(node[N_PARENT])  # [N_PARENT], '/%s'%node[N_NAME])
+            return f_xpath(node[N_PARENT])  # [N_PARENT], '/%s'%name)
         return f_xpath(node[N_PARENT], '/%s[%d]%s' % (
-            node[N_NAME], node[N_XNUM], x))
+            name, node[N_XNUM], x))
     elif not x:
         return '/'
     return x

--- a/tests/test_regrtest.py
+++ b/tests/test_regrtest.py
@@ -34,15 +34,15 @@ def get_output(options):
     backup = sys.stdout
 
     # capture stdout
-    sys.stdout = six.StringIO()
+    sys.stdout = out = six.StringIO()
     try:
         main.run(options)
     except SystemExit:
         pass
     finally:
-        output = sys.stdout.getvalue().strip()
-        sys.stdout.close()
         sys.stdout = backup
+        output = out.getvalue().strip()
+        out.close()
 
     return output
 
@@ -157,9 +157,8 @@ def test_known(fnames, lcs2_type):
     old = fnames['old']
     new = fnames['new']
     res_file = fnames['result']
-    f = open(res_file)
-    expected = f.read().strip()
-    f.close()
+    with open(res_file) as f:
+        expected = f.read().strip()
     options = [old, new]
     data = get_output(options)
     assert data == expected, '%s:\n%r != %r' % (options, data, expected)


### PR DESCRIPTION
The original fix fixed too much. This fix does the right thing, but changes
the return format of the parser by adding a field for the namespace prefix.