### PR TITLE
fix issue #38

### DIFF
--- a/xmldiff/diff.py
+++ b/xmldiff/diff.py
@@ -258,6 +258,8 @@ class Differ(object):
                 yield actions.RenameAttrib(left_xpath, lk, rk)
                 # Remove from list of new attributes
                 new_keys.remove(rk)
+                # Delete used attribute from map of attributes
+                del newattrmap[value]
                 # Update left node
                 left.attrib[rk] = value
                 del left.attrib[lk]


### PR DESCRIPTION
Fix for issue #38.

If multiple attributes has same value,  code tries to map attribute into same name. On second occurrence of same value, first attribute is taken. Code that fails on 'new_keys.remove(rk)'.

Removing used attributes from "newattrmap" fixes issue.

Fixed code has passed "make test".

