### PR TITLE
Allow specifying a pair of  (tag, attr) in uniqueattrs.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,9 @@ Changes
 2.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
+- Added an option to pass pairs of (element, attr) as unique
+  attributes for tree matching.  Exposed this option on the command
+  line, too.
 
 2.3 (2019-02-27)
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -82,5 +82,7 @@ Contributors
 
  * Stephan Richter, srichter@shoobx.com
 
+ * Albertas Agejevas, alga@shoobx.com
+
 The diff algorithm is based on "`Change Detection in Hierarchically Structured Information <http://ilpubs.stanford.edu/115/1/1995-46.pdf>`_",
 and the text diff is using Google's ``diff_match_patch`` algorithm.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -98,7 +98,7 @@ The included formatters, ``diff``, ``xml``, and ``old`` all return a Unicode str
 and no guarantees are done that the output of one version will be the same as the output of any previous version.
 The actions of the edit script can be in a different order or replaced by equivalent actions dependingon the version of ``xmldiff``,
 but if the Edit Script does not correctly transform one XML tree into another,
-thas is regarded as a bug.
+that is regarded as a bug.
 This means that the output of the ``xml`` format also may change from version to version.
 There is no "correct" solution to how that output should look,
 as the same change can be represented in several different ways.
@@ -107,11 +107,17 @@ as the same change can be represented in several different ways.
 Unique Attributes
 -----------------
 
-The ``uniqueattrs`` argument is a list of strings specifying attributes that uniquely identify a node in the document.
+The ``uniqueattrs`` argument is a list of strings or ``(tag, attribute)`` tuples
+specifying attributes that uniquely identify a node in the document.
 This is used by the differ when trying to match nodes.
 If one node in the left tree has a this attribute,
 the node in the right three with the same value for that attribute will match,
 regardless of other attributes, child nodes or text content.
+Respectively, if the values of the attribute on the nodes in question are different,
+or if only one of the nodes has this attribute,
+the nodes will not match regardless of their structural similarity.
+In case the attribute is a tuple, the attribute match applies only if both nodes
+have the given tag.
 
 The default is ``['{http://www.w3.org/XML/1998/namespace}id']``,
 which is the ``xml:id`` attribute.

--- a/xmldiff/diff.py
+++ b/xmldiff/diff.py
@@ -14,8 +14,9 @@ class Differ(object):
         if F is None:
             F = 0.5
         self.F = F
-        # uniqueattrs is a list of attributes that uniquely identifies a node
-        # inside a document. Defaults to 'xml:id'.
+        # uniqueattrs is a list of attributes or (tag, attribute) pairs
+        # that uniquely identifies a node inside a document. Defaults
+        # to 'xml:id'.
         if uniqueattrs is None:
             uniqueattrs = ['{http://www.w3.org/XML/1998/namespace}id']
         self.uniqueattrs = uniqueattrs
@@ -162,6 +163,12 @@ class Differ(object):
             return 0
 
         for attr in self.uniqueattrs:
+            if not isinstance(attr, str):
+                # If it's actually a sequence of (tag, attr), the tags must
+                # match first.
+                tag, attr = attr
+                if tag != left.tag or tag != right.tag:
+                    continue
             if attr in left.attrib or attr in right.attrib:
                 # One of the nodes have a unique attribute, we check only that.
                 # If only one node has it, it means they are not the same.

--- a/xmldiff/main.py
+++ b/xmldiff/main.py
@@ -87,6 +87,15 @@ def make_diff_parser():
     return parser
 
 
+def _parse_uniqueattrs(uniqueattrs):
+    if uniqueattrs is None:
+        return []
+    return [
+        attr if '@' not in attr else attr.split('@', 1)
+        for attr in uniqueattrs.split(',')
+    ]
+
+
 def diff_command(args=None):
     parser = make_diff_parser()
     args = parser.parse_args(args=args)
@@ -99,18 +108,10 @@ def diff_command(args=None):
     formatter = FORMATTERS[args.formatter](normalize=normalize,
                                            pretty_print=args.pretty_print)
 
-    if args.unique_attributes is None:
-        uniqueattrs = []
-    else:
-        uniqueattrs = [
-            attr if '@' not in attr else attr.split('@', 1)
-            for attr in args.unique_attributes.split(',')
-        ]
-
     diff_options = {'ratio_mode': args.ratio_mode,
                     'F': args.F,
                     'fast_match': args.fast_match,
-                    'uniqueattrs': uniqueattrs,
+                    'uniqueattrs': _parse_uniqueattrs(args.unique_attributes),
                     }
     result = diff_files(args.file1, args.file2, diff_options=diff_options,
                         formatter=formatter)

--- a/xmldiff/main.py
+++ b/xmldiff/main.py
@@ -76,7 +76,9 @@ def make_diff_parser():
     parser.add_argument('--unique-attributes', type=str, nargs='?',
                         default='{http://www.w3.org/XML/1998/namespace}id',
                         help='A comma separated list of attributes '
-                             'that uniquely identify a node. Can be empty.')
+                             'that uniquely identify a node. Can be empty. '
+                             'Unique attributes for certain elements can '
+                             'be specified in the format {NS}element@attr.')
     parser.add_argument('--ratio-mode', default='fast',
                         choices={'accurate', 'fast', 'faster'},
                         help='Choose the node comparison optimization.')
@@ -100,7 +102,10 @@ def diff_command(args=None):
     if args.unique_attributes is None:
         uniqueattrs = []
     else:
-        uniqueattrs = args.unique_attributes.split(',')
+        uniqueattrs = [
+            attr if '@' not in attr else attr.split('@', 1)
+            for attr in args.unique_attributes.split(',')
+        ]
 
     diff_options = {'ratio_mode': args.ratio_mode,
                     'F': args.F,


### PR DESCRIPTION
This allows helping the tree matching algorithm do the right thing when some elements can be uniquely identified by an attribute other than `xml:id`.