### PR TITLE
Allowing for multiple unique attributes using dictionary

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -52,7 +52,7 @@ Parameters
     Set the value low, and you will get more updates instead of inserts and deletes.
 
     ``uniqueattrs``:
-    A list of XML node attributes that will uniquely identify a node.
+    A list of XML node attributes that will uniquely identify a node. Alternatively, a dictionary containing unique keys for different tags.
     See `Unique Attributes`_ for more info.
 
     Defaults to ``['{http://www.w3.org/XML/1998/namespace}id']``.
@@ -107,8 +107,8 @@ as the same change can be represented in several different ways.
 Unique Attributes
 -----------------
 
-The ``uniqueattrs`` argument is a list of strings or ``(tag, attribute)`` tuples
-specifying attributes that uniquely identify a node in the document.
+The ``uniqueattrs`` argument is a list of strings or alternatively a dictionary where keys denote tags and values list of attributes which collectively 
+uniquely identify a node in the document.
 This is used by the differ when trying to match nodes.
 If one node in the left tree has a this attribute,
 the node in the right three with the same value for that attribute will match,

--- a/xmldiff/diff.py
+++ b/xmldiff/diff.py
@@ -162,18 +162,22 @@ class Differ(object):
             # One is a comment the other is not:
             return 0
 
-        for attr in self.uniqueattrs:
-            if not isinstance(attr, str):
-                # If it's actually a sequence of (tag, attr), the tags must
-                # match first.
-                tag, attr = attr
-                if tag != left.tag or tag != right.tag:
+        if isinstance(self.uniqueattrs, dict):
+            for tag, attr_list in self.uniqueattrs.items():
+                if tag!= left.tag or tag != right.tag:
                     continue
-            if attr in left.attrib or attr in right.attrib:
-                # One of the nodes have a unique attribute, we check only that.
-                # If only one node has it, it means they are not the same.
-                return int(left.attrib.get(attr) == right.attrib.get(attr))
-
+                ratio = 0
+                for attr in attr_list:
+                    if attr in left.attrib or attr in right.attrib:
+                        ratio += int(left.attrib.get(attr) == right.attrib.get(attr))
+                return ratio/len(attr_list)
+        else:     
+            for attr in self.uniqueattrs:
+                if attr in left.attrib or attr in right.attrib:
+                    # One of the nodes have a unique attribute, we check only that.
+                    # If only one node has it, it means they are not the same.
+                    return int(left.attrib.get(attr) == right.attrib.get(attr))
+            
         match = self.leaf_ratio(left, right)
         child_ratio = self.child_ratio(left, right)
 


### PR DESCRIPTION
Currently, the option unique attributes only uses one unique attribute at a time for matching i.e. if one unique attribute is equal across two elements, the elements are considered a match. 
When working with XML representation of databases however, often primary keys consist of multiple values. Therefore when comparing such XML one wants elements to be a match only if all the attributes representing the primary key are equal.
This fix allows for passing a dictionary for uniqueattrs: { tag: [attr1, attr2...attrn]} where for each tag, an element of that same tag is considered a match if and only if ALL the attribtues attr1...attrn are equal. 
Alternatively, one can enter a list of attributes and use the uniqueattr option like beforehand. 
