### PR TITLE
Allowing to pass multiple unique attributes for tags in a dictionary

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,10 @@
 Changes
 =======
 
-2.5 (unreleased)
+2.5 (2020-02-17)
 ----------------
 
-- Nothing changed yet.
+- Added an option to pass {element: [attr1...attrN]} dictionary as unique attribute for tree matching.
 
 
 2.4 (2019-10-09)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -52,7 +52,7 @@ Parameters
     Set the value low, and you will get more updates instead of inserts and deletes.
 
     ``uniqueattrs``:
-    A list of XML node attributes that will uniquely identify a node.
+    A list of XML node attributes that will uniquely identify a node. Alternatively, a dictionary containing unique keys for different tags.
     See `Unique Attributes`_ for more info.
 
     Defaults to ``['{http://www.w3.org/XML/1998/namespace}id']``.
@@ -107,8 +107,9 @@ as the same change can be represented in several different ways.
 Unique Attributes
 -----------------
 
-The ``uniqueattrs`` argument is a list of strings or ``(tag, attribute)`` tuples
-specifying attributes that uniquely identify a node in the document.
+The ``uniqueattrs`` argument is a list of strings or, alternatively,
+a dictionary where keys denote tags and values denote a list of attributes,
+which collectively uniquely identify a node in the document.
 This is used by the differ when trying to match nodes.
 If one node in the left tree has a this attribute,
 the node in the right three with the same value for that attribute will match,
@@ -116,8 +117,9 @@ regardless of other attributes, child nodes or text content.
 Respectively, if the values of the attribute on the nodes in question are different,
 or if only one of the nodes has this attribute,
 the nodes will not match regardless of their structural similarity.
-In case the attribute is a tuple, the attribute match applies only if both nodes
-have the given tag.
+In case the attribute is a dictionary,
+the attribute match applies only if both nodes have the given tag.
+Furthermore, in this case a match is only found if all attributes are equal.
 
 The default is ``['{http://www.w3.org/XML/1998/namespace}id']``,
 which is the ``xml:id`` attribute.

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -353,12 +353,16 @@ class NodeRatioTests(unittest.TestCase):
                     <para>First paragraph</para>
                     <para>This is the second paragraph</para>
                 </subsection>
+                <section name="oldfirst" single-ref="2" ref="1">
+                    <para>This is the second</para>
+                    <para>Det tredje stycket</para>
+                </section>
             </story>
         </document>
         """)
 
         differ = Differ(uniqueattrs=[
-            ('section', 'name'),
+            {'section': ['name', 'ref']},
             '{http://www.w3.org/XML/1998/namespace}id'
         ])
         differ.set_trees(etree.fromstring(left), etree.fromstring(right))
@@ -382,8 +386,8 @@ class NodeRatioTests(unittest.TestCase):
 
         # Only one out of two children in common
         self.assertEqual(differ.child_ratio(left, right), 0)
-        # But same id's, hence 1 as match
-        self.assertEqual(differ.node_ratio(left, right), 1.0)
+        # They differ on the ref attribute, hence no match
+        self.assertEqual(differ.node_ratio(left, right), 0)
 
         # The last ones are completely similar, but only one
         # has an name, so they do not match.
@@ -400,6 +404,15 @@ class NodeRatioTests(unittest.TestCase):
         self.assertAlmostEqual(differ.leaf_ratio(left, right), 1.0)
         self.assertEqual(differ.child_ratio(left, right), 0.5)
         self.assertAlmostEqual(differ.node_ratio(left, right), 0.75)
+
+        # Here's the ones with the same tag and name attribute:
+        left = differ.left.xpath('/document/story/section[1]')[0]
+        right = differ.right.xpath('/document/story/section[4]')[0]
+
+        # Only one out of two children in common
+        self.assertEqual(differ.child_ratio(left, right), 0)
+        # They are equal both on the name and the ref attribute, hence a match
+        self.assertEqual(differ.node_ratio(left, right), 1.0)
 
     def test_compare_node_rename(self):
         left = u"""<document>


### PR DESCRIPTION
Extending the option 'uniqueattrs' by allowing to pass a dictionary where key denotes the tagname and value denotes a list of attributes which must be equal for nodes to match. This extends the current  (tag, attribute)-tuple by providing the possibility to have multiple attributes which must be equal for a match. Helpful for XML represented databases where primary keys consist of multilple fields