### PR TITLE
Make it possible to adjust the attributes used when comparing nodes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 2.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Make it possible to adjust the attributes considered when comparing nodes.
 
 
 2.4 (2019-10-09)

--- a/README.rst
+++ b/README.rst
@@ -84,5 +84,7 @@ Contributors
 
  * Albertas Agejevas, alga@shoobx.com
 
+ * Greg Kempe, greg@laws.africa
+
 The diff algorithm is based on "`Change Detection in Hierarchically Structured Information <http://ilpubs.stanford.edu/115/1/1995-46.pdf>`_",
 and the text diff is using Google's ``diff_match_patch`` algorithm.

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1471,9 +1471,9 @@ class DiffTests(unittest.TestCase):
         # this differ ignores the attribute 'skip' when diffing
         class IgnoringDiffer(Differ):
             def node_attribs(self, node):
-                if 'skip' in node.attrib:
+                if "skip" in node.attrib:
                     attribs = dict(node.attrib)
-                    del attribs['skip']
+                    del attribs["skip"]
                     return attribs
                 return node.attrib
 

--- a/xmldiff/diff.py
+++ b/xmldiff/diff.py
@@ -198,8 +198,7 @@ class Differ:
         return result
 
     def node_attribs(self, node):
-        """ Return a dict of attributes to consider for this node.
-        """
+        """Return a dict of attributes to consider for this node."""
         return node.attrib
 
     def leaf_ratio(self, left, right):

--- a/xmldiff/diff.py
+++ b/xmldiff/diff.py
@@ -186,7 +186,7 @@ class Differ:
         texts = node.xpath("text()")
 
         # Then add attributes and values
-        for tag, value in sorted(node.attrib.items()):
+        for tag, value in sorted(self.node_attribs(node).items()):
             if tag[0] == "{":
                 tag = tag.split("}",)[-1]
             texts.append(f"{tag}:{value}")
@@ -196,6 +196,11 @@ class Differ:
         result = utils.cleanup_whitespace(text)
         self._text_cache[node] = result
         return result
+
+    def node_attribs(self, node):
+        """ Return a dict of attributes to consider for this node.
+        """
+        return node.attrib
 
     def leaf_ratio(self, left, right):
         # How similar two nodes are, with no consideration of their children
@@ -235,8 +240,8 @@ class Differ:
 
         # Update: Look for differences in attributes
 
-        left_keys = set(left.attrib.keys())
-        right_keys = set(right.attrib.keys())
+        left_keys = set(self.node_attribs(left).keys())
+        right_keys = set(self.node_attribs(right).keys())
         new_keys = right_keys.difference(left_keys)
         removed_keys = left_keys.difference(right_keys)
         common_keys = left_keys.intersection(right_keys)


### PR DESCRIPTION
Subclasses can use this determine which attributes for a node should be considered when diffing. By default, they are all considered.

This makes it possible to ignore an attribute on a particular node when calculating diffs, without removing it from the XML tree before hand and having to add it back after the diff.