### PR TITLE
Files are now explicitly opened in UTF-8...

### DIFF
--- a/tests/test_data/bom_1.xml
+++ b/tests/test_data/bom_1.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<metadataRoot>
+    <cubes>
+        <cube name="MFG_BU"></cube>
+    </cubes>
+</metadataRoot>

--- a/tests/test_data/bom_2.xml
+++ b/tests/test_data/bom_2.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<metadataRoot>
+    <cubes>
+        <cube name="SVC_BU"></cube>
+    </cubes>
+</metadataRoot>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -103,6 +103,18 @@ class MainCLITests(unittest.TestCase):
         # This should default to the diff formatter:
         self.assertEqual(output[0], "[")
 
+    def test_diff_cli_BOM(self):
+        """ Test comparison of files encoded with UTF-8 prepended by Byte Order Mark """
+        curdir = os.path.dirname(__file__)
+        filepath = os.path.join(curdir, "test_data")
+        file1 = os.path.join(filepath, "bom_1.xml")
+        file2 = os.path.join(filepath, "bom_2.xml")
+
+        output, errors = self.call_run([file1, file2])
+        self.assertEqual(len(output.splitlines()), 1)
+        # This should default to the diff formatter:
+        self.assertEqual(output[0], "[")
+
     def test_diff_cli_args(self):
         curdir = os.path.dirname(__file__)
         filepath = os.path.join(curdir, "test_data")

--- a/xmldiff/main.py
+++ b/xmldiff/main.py
@@ -38,7 +38,6 @@ def _diff(parse_method, left, right, diff_options=None, formatter=None):
         left_tree, right_tree, diff_options=diff_options, formatter=formatter
     )
 
-
 def diff_texts(left, right, diff_options=None, formatter=None):
     """Takes two Unicode strings containing XML"""
     return _diff(
@@ -57,8 +56,8 @@ def make_diff_parser():
     parser = ArgumentParser(
         description="Create a diff for two XML files.", add_help=False
     )
-    parser.add_argument("file1", type=FileType("r"), help="The first input file.")
-    parser.add_argument("file2", type=FileType("r"), help="The second input file.")
+    parser.add_argument("file1", type=FileType("r", encoding="utf-8-sig"), help="The first input file.")
+    parser.add_argument("file2", type=FileType("r", encoding="utf-8-sig"), help="The second input file.")
     parser.add_argument(
         "-h", "--help", action="help", help="Show this help message and exit."
     )
@@ -185,8 +184,8 @@ def make_patch_parser():
     parser = ArgumentParser(
         description="Patch an XML file with an xmldiff", add_help=False
     )
-    parser.add_argument("patchfile", type=FileType("r"), help="An xmldiff diff file.")
-    parser.add_argument("xmlfile", type=FileType("r"), help="An unpatched XML file.")
+    parser.add_argument("patchfile", type=FileType("r", encoding="utf-8-sig"), help="An xmldiff diff file.")
+    parser.add_argument("xmlfile", type=FileType("r", encoding="utf-8-sig"), help="An unpatched XML file.")
     parser.add_argument(
         "-h", "--help", action="help", help="Show this help message and exit."
     )


### PR DESCRIPTION
…(which XML requires anyway) rather than default encodings. This ensures BOM-prepended files are handled properly. Provided test case. 

Fixes #72 