### PR TITLE
Removed use of FileType in argument specification

### DIFF
--- a/tests/test_data/bom_1.xml
+++ b/tests/test_data/bom_1.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<metadataRoot>
+    <cubes>
+        <cube name="MFG_BU"></cube>
+    </cubes>
+</metadataRoot>

--- a/tests/test_data/bom_2.xml
+++ b/tests/test_data/bom_2.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<metadataRoot>
+    <cubes>
+        <cube name="SVC_BU"></cube>
+    </cubes>
+</metadataRoot>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -103,6 +103,18 @@ class MainCLITests(unittest.TestCase):
         # This should default to the diff formatter:
         self.assertEqual(output[0], "[")
 
+    def test_diff_cli_BOM(self):
+        """ Test comparison of files encoded with UTF-8 prepended by Byte Order Mark """
+        curdir = os.path.dirname(__file__)
+        filepath = os.path.join(curdir, "test_data")
+        file1 = os.path.join(filepath, "bom_1.xml")
+        file2 = os.path.join(filepath, "bom_2.xml")
+
+        output, errors = self.call_run([file1, file2])
+        self.assertEqual(len(output.splitlines()), 1)
+        # This should default to the diff formatter:
+        self.assertEqual(output[0], "[")
+
     def test_diff_cli_args(self):
         curdir = os.path.dirname(__file__)
         filepath = os.path.join(curdir, "test_data")

--- a/xmldiff/main.py
+++ b/xmldiff/main.py
@@ -1,7 +1,7 @@
 """All major API points and command-line tools"""
 import pkg_resources
 
-from argparse import ArgumentParser, FileType
+from argparse import ArgumentParser
 from lxml import etree
 from xmldiff import diff, formatting, patch
 
@@ -57,8 +57,8 @@ def make_diff_parser():
     parser = ArgumentParser(
         description="Create a diff for two XML files.", add_help=False
     )
-    parser.add_argument("file1", type=FileType("r"), help="The first input file.")
-    parser.add_argument("file2", type=FileType("r"), help="The second input file.")
+    parser.add_argument("file1", type=str, help="The first input file.")
+    parser.add_argument("file2", type=str, help="The second input file.")
     parser.add_argument(
         "-h", "--help", action="help", help="Show this help message and exit."
     )
@@ -185,8 +185,8 @@ def make_patch_parser():
     parser = ArgumentParser(
         description="Patch an XML file with an xmldiff", add_help=False
     )
-    parser.add_argument("patchfile", type=FileType("r"), help="An xmldiff diff file.")
-    parser.add_argument("xmlfile", type=FileType("r"), help="An unpatched XML file.")
+    parser.add_argument("patchfile", type=str, help="An xmldiff diff file.")
+    parser.add_argument("xmlfile", type=str, help="An unpatched XML file.")
     parser.add_argument(
         "-h", "--help", action="help", help="Show this help message and exit."
     )


### PR DESCRIPTION
This allows us to handle files directly in lxml, which solves #72 and likely increases performance and exactness all around.