### PR TITLE
Get version with importlib.metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 2.7 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Changed usage of deprecated `pkg_resources` package to `importlib.metadata`
 
 
 2.6 (2023-04-03)

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ package_dir =
 install_requires =
     setuptools
     lxml>=3.1.0
+    importlib-metadata;python_version<'3.10'
 
 [options.packages.find]
 where = .

--- a/xmldiff/main.py
+++ b/xmldiff/main.py
@@ -1,11 +1,15 @@
 """All major API points and command-line tools"""
-import pkg_resources
+import sys
 
 from argparse import ArgumentParser
 from lxml import etree
 from xmldiff import diff, formatting, patch
 
-__version__ = pkg_resources.require("xmldiff")[0].version
+if sys.version_info < (3, 10):  # pragma: no cover (PY310+)
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
+__version__ = importlib_metadata.version("xmldiff")
 
 FORMATTERS = {
     "diff": formatting.DiffFormatter,


### PR DESCRIPTION
`pkg_resources` that was used to get package version is a deprecated API: https://setuptools.pypa.io/en/latest/pkg_resources.html