### PR TITLE
XMLFormatter option for replace tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ docs/build
 venv
 build
 dist
+test.ipynb
+.venv/

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,7 @@
+- Added option to XMLFormatter to use replace tags
+
+- in _make_diff_tags after diffing, neighboring delete/insert diffs are joined to a replace tag
+
+- the deleted text is added as an attribute ("old-text")
+
+- the inserted text is the element's text

--- a/README.rst
+++ b/README.rst
@@ -88,5 +88,7 @@ Contributors
 
  * Filip Demski, glamhoth@protonmail.com
 
+ * Thomas Pfitzinger, thpfitzinger@web.de
+
 The diff algorithm is based on "`Change Detection in Hierarchically Structured Information <http://ilpubs.stanford.edu/115/1/1995-46.pdf>`_",
 and the text diff is using Google's ``diff_match_patch`` algorithm.

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -16,13 +16,13 @@ class PlaceholderMakerTests(unittest.TestCase):
         replacer = formatting.PlaceholderMaker()
         # Get a placeholder:
         ph = replacer.get_placeholder(etree.Element("tag"), formatting.T_OPEN, None)
-        self.assertEqual(ph, "\ue005")
+        self.assertEqual(ph, "\ue007")
         # Do it again:
         ph = replacer.get_placeholder(etree.Element("tag"), formatting.T_OPEN, None)
-        self.assertEqual(ph, "\ue005")
+        self.assertEqual(ph, "\ue007")
         # Get another one
         ph = replacer.get_placeholder(etree.Element("tag"), formatting.T_CLOSE, ph)
-        self.assertEqual(ph, "\ue006")
+        self.assertEqual(ph, "\ue008")
 
     def test_do_element(self):
         replacer = formatting.PlaceholderMaker(["p"], ["b"])
@@ -34,7 +34,7 @@ class PlaceholderMakerTests(unittest.TestCase):
 
         self.assertEqual(
             etree.tounicode(element),
-            "<p>This is a tag with \ue006formatted\ue005 text.</p>",
+            "<p>This is a tag with \ue008formatted\ue007 text.</p>",
         )
 
         replacer.undo_element(element)
@@ -45,14 +45,14 @@ class PlaceholderMakerTests(unittest.TestCase):
         element = etree.fromstring(text)
         replacer.do_element(element)
         result = etree.tounicode(element)
-        self.assertEqual(result, "<p>This is a tag with \ue007 text.</p>")
+        self.assertEqual(result, "<p>This is a tag with \ue009 text.</p>")
 
         # Single formatting tags still get two placeholders.
         text = "<p>This is a <b/> with <foo/> text.</p>"
         element = etree.fromstring(text)
         replacer.do_element(element)
         result = etree.tounicode(element)
-        self.assertEqual(result, "<p>This is a \ue009\ue008 with \ue00a text.</p>")
+        self.assertEqual(result, "<p>This is a \ue00b\ue00a with \ue00c text.</p>")
 
     def test_do_undo_element(self):
         replacer = formatting.PlaceholderMaker(["p"], ["b"])
@@ -63,7 +63,7 @@ class PlaceholderMakerTests(unittest.TestCase):
         replacer.do_element(element)
 
         self.assertEqual(
-            element.text, "This \ue005 a \ue006 with \ue008formatted" "\ue007 text."
+            element.text, "This \ue007 a \ue008 with \ue00aformatted" "\ue009 text."
         )
 
         replacer.undo_element(element)
@@ -79,7 +79,7 @@ class PlaceholderMakerTests(unittest.TestCase):
         replacer.do_element(element)
 
         self.assertEqual(
-            element.text, "This is \ue006doubly \ue008formatted\ue007" "\ue005 text."
+            element.text, "This is \ue008doubly \ue00aformatted\ue009" "\ue007 text."
         )
 
         replacer.undo_element(element)
@@ -110,8 +110,8 @@ class PlaceholderMakerTests(unittest.TestCase):
         after_diff = """<document xmlns:diff="http://namespaces.shoobx.com/diff">
   <section>
     <para>
-      <insert>\ue005</insert>.
-      \ue007\ue009At Will Employment\ue008\ue006
+      <insert>\ue007</insert>.
+      \ue009\ue00bAt Will Employment\ue00a\ue008
       .\u201c<insert>New </insert>Text\u201d
     </para>
   </section>
@@ -119,8 +119,8 @@ class PlaceholderMakerTests(unittest.TestCase):
 
         # The diff formatting will find some text to insert.
         delete_attrib = "{%s}delete-format" % formatting.DIFF_NS
-        replacer.placeholder2tag["\ue006"].element.attrib[delete_attrib] = ""
-        replacer.placeholder2tag["\ue007"].element.attrib[delete_attrib] = ""
+        replacer.placeholder2tag["\ue008"].element.attrib[delete_attrib] = ""
+        replacer.placeholder2tag["\ue009"].element.attrib[delete_attrib] = ""
         tree = etree.fromstring(after_diff)
         replacer.undo_tree(tree)
         result = etree.tounicode(tree)
@@ -153,7 +153,7 @@ class PlaceholderMakerTests(unittest.TestCase):
 
             #
             self.assertEqual(
-                element.text, "This \uf904 a \uf905 with \uf907some" "\uf906 text."
+                element.text, "This \uf906 a \uf907 with \uf909some" "\uf908 text."
             )
 
             try:
@@ -172,8 +172,8 @@ class PlaceholderMakerTests(unittest.TestCase):
                 # This should raise an error on a narrow build
                 self.assertEqual(
                     element.text,
-                    "This \U00010004 a \U00010005 with \U00010007some"
-                    "\U00010006 text.",
+                    "This \U00010006 a \U00010007 with \U00010009some"
+                    "\U00010008 text.",
                 )
             except ValueError:
                 if sys.maxunicode > 0x10000:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -352,6 +352,16 @@ class XMLFormatTests(unittest.TestCase):
 
         self._format_test(left, action, expected, use_replace=True)
 
+    def test_replace_complete_text(self):
+        left = "<document><node>aaaaaaa bbbbbb</node></document>"
+        action = actions.UpdateTextIn("/document/node", "ccccc dddd eee")
+        expected = (
+            START + "><diff:replace old-text=\"aaaaaaa bbbbbb\">ccccc dddd eee"
+            "</diff:replace>" + END
+        )
+
+        self._format_test(left, action, expected, use_replace=True)
+
 class DiffFormatTests(unittest.TestCase):
     def _format_test(self, action, expected):
         formatter = formatting.DiffFormatter()

--- a/xmldiff/diff_match_patch.py
+++ b/xmldiff/diff_match_patch.py
@@ -1196,7 +1196,7 @@ class diff_match_patch:
           Destination text.
         """
         text = []
-        for op, data in diffs:
+        for (op, data) in diffs:
             if op != self.DIFF_DELETE:
                 text.append(data)
         return "".join(text)

--- a/xmldiff/diff_match_patch.py
+++ b/xmldiff/diff_match_patch.py
@@ -83,11 +83,12 @@ class diff_match_patch:
     Also contains the behaviour settings.
     """
 
-    def __init__(self):
+    def __init__(self, use_replace=False):
         """Inits a diff_match_patch object with default settings.
         Redefine these in your program to override the defaults.
         """
 
+        self.use_replace = use_replace
         # Number of seconds to map a diff before giving up (0 for infinity).
         self.Diff_Timeout = 1.0
         # Cost of an empty edit operation in terms of edit characters.
@@ -223,7 +224,10 @@ class diff_match_patch:
         if len(shorttext) == 1:
             # Single character string.
             # After the previous speedup, the character can't be an equality.
-            return [diff_object(self.DIFF_REPLACE, text2, text1)]
+            if self.use_replace:
+                return [diff_object(self.DIFF_REPLACE, text2, text1)]
+            return [diff_object(self.DIFF_DELETE, text1), 
+                    diff_object(self.DIFF_INSERT, text2)]
 
         # Check to see if the problem can be split in two.
         hm = self.diff_halfMatch(text1, text2)
@@ -398,7 +402,11 @@ class diff_match_patch:
 
         # Diff took too long and hit the deadline or
         # number of diffs equals number of characters, no commonality at all.
-        return [diff_object(self.DIFF_REPLACE, text2, text1)]
+        if self.use_replace:
+            return [diff_object(self.DIFF_REPLACE, text2, text1)]
+        else:
+            return [diff_object(self.DIFF_DELETE, text1), 
+                    diff_object(self.DIFF_INSERT, text2)]
 
     def diff_bisectSplit(self, text1, text2, x, y, deadline):
         """Given the location of the 'middle snake', split the diff in two parts

--- a/xmldiff/diff_match_patch.py
+++ b/xmldiff/diff_match_patch.py
@@ -1133,9 +1133,9 @@ class diff_match_patch:
         last_chars2 = 0
         for x in range(len(diffs)):
             (op, text) = diffs[x]
-            if op != self.DIFF_INSERT:  # Equality or deletion.
+            if op == self.DIFF_EQUAL or op == self.DIFF_DELETE:  # Equality or deletion.
                 chars1 += len(text)
-            if op != self.DIFF_DELETE:  # Equality or insertion.
+            if op == self.DIFF_EQUAL or op == self.DIFF_INSERT:  # Equality or insertion.
                 chars2 += len(text)
             if chars1 > loc:  # Overshot the location.
                 break

--- a/xmldiff/diff_match_patch.py
+++ b/xmldiff/diff_match_patch.py
@@ -994,10 +994,8 @@ class diff_match_patch:
         pointer = 0
         count_delete = 0
         count_insert = 0
-        count_replace = 0
         text_delete = ""
         text_insert = ""
-        text_replace = ""
         while pointer < len(diffs):
             if diffs[pointer][0] == self.DIFF_INSERT:
                 count_insert += 1
@@ -1007,18 +1005,14 @@ class diff_match_patch:
                 count_delete += 1
                 text_delete += diffs[pointer][1]
                 pointer += 1
-            elif diffs[pointer][0] == self.DIFF_REPLACE:
-                count_replace += 1
-                text_replace += diffs[pointer][1]
-                pointer += 1
-            elif diffs[pointer][0] == self.DIFF_EQUAL:
+            elif diffs[pointer][0] == self.DIFF_EQUAL or diffs[pointer][0] == self.DIFF_REPLACE:
                 # Upon reaching an equality, check for prior redundancies.
-                if count_delete + count_insert + count_replace > 1:
-                    if count_delete != 0 and count_insert != 0 and count_replace != 0:
+                if count_delete + count_insert > 1:
+                    if count_delete != 0 and count_insert != 0:
                         # Factor out any common prefixies.
                         commonlength = self.diff_commonPrefix(text_insert, text_delete)
                         if commonlength != 0:
-                            x = pointer - count_delete - count_insert - count_replace - 1
+                            x = pointer - count_delete - count_insert - 1
                             if x >= 0 and diffs[x][0] == self.DIFF_EQUAL:
                                 diffs[x] = (
                                     diffs[x][0],
@@ -1046,8 +1040,8 @@ class diff_match_patch:
                         new_ops.append((self.DIFF_DELETE, text_delete))
                     if len(text_insert) != 0:
                         new_ops.append((self.DIFF_INSERT, text_insert))
-                    pointer -= count_delete + count_insert + count_replace
-                    diffs[pointer : pointer + count_delete + count_insert + count_replace] = new_ops
+                    pointer -= count_delete + count_insert
+                    diffs[pointer : pointer + count_delete + count_insert] = new_ops
                     pointer += len(new_ops) + 1
                 elif pointer != 0 and diffs[pointer - 1][0] == self.DIFF_EQUAL:
                     # Merge this equality with the previous one.
@@ -1061,10 +1055,8 @@ class diff_match_patch:
 
                 count_insert = 0
                 count_delete = 0
-                count_replace = 0
                 text_delete = ""
                 text_insert = ""
-                text_replace = ""
             else:
                 raise Exception(f"Unknown diff type {diffs[pointer][0]}")
 

--- a/xmldiff/diff_match_patch.py
+++ b/xmldiff/diff_match_patch.py
@@ -74,6 +74,7 @@ class diff_match_patch:
     DIFF_DELETE = -1
     DIFF_INSERT = 1
     DIFF_EQUAL = 0
+    DIFF_REPLACE = 2
 
     def diff_main(self, text1, text2, checklines=True, deadline=None):
         """Find the differences between two texts.  Simplifies the problem by

--- a/xmldiff/diff_match_patch.py
+++ b/xmldiff/diff_match_patch.py
@@ -188,8 +188,8 @@ class diff_match_patch:
             # After the previous speedup, the character can't be an equality.
             if self.use_replace:
                 return [(self.DIFF_REPLACE, text2, text1)]
-            return [(self.DIFF_DELETE, text1), 
-                    (self.DIFF_INSERT, text2)]
+            else:
+                return [(self.DIFF_DELETE, text1), (self.DIFF_INSERT, text2)]
 
         # Check to see if the problem can be split in two.
         hm = self.diff_halfMatch(text1, text2)
@@ -204,6 +204,7 @@ class diff_match_patch:
 
         if checklines and len(text1) > 100 and len(text2) > 100:
             return self.diff_lineMode(text1, text2, deadline)
+        
         return self.diff_bisect(text1, text2, deadline)
 
     def diff_lineMode(self, text1, text2, deadline):
@@ -276,6 +277,7 @@ class diff_match_patch:
         Returns:
           Array of diff tuples.
         """
+
         # Cache the text lengths to prevent multiple calls.
         text1_length = len(text1)
         text2_length = len(text2)
@@ -367,8 +369,7 @@ class diff_match_patch:
         if self.use_replace:
             return [(self.DIFF_REPLACE, text2, text1)]
         else:
-            return [(self.DIFF_DELETE, text1), 
-                    (self.DIFF_INSERT, text2)]
+            return [(self.DIFF_DELETE, text1), (self.DIFF_INSERT, text2)]
 
     def diff_bisectSplit(self, text1, text2, x, y, deadline):
         """Given the location of the 'middle snake', split the diff in two parts
@@ -1106,7 +1107,7 @@ class diff_match_patch:
                         + diffs[pointer + 1][1],
                     )
                     del diffs[pointer + 1]
-                    changes = Truediff
+                    changes = True
             pointer += 1
 
         # If shifts were made, the diff needs reordering and another shift sweep.
@@ -1155,7 +1156,7 @@ class diff_match_patch:
           HTML representation.
         """
         html = []
-        for op, data in diffs:
+        for (op, data) in diffs:
             text = (
                 data.replace("&", "&amp;")
                 .replace("<", "&lt;")
@@ -1180,7 +1181,7 @@ class diff_match_patch:
           Source text.
         """
         text = []
-        for op, data in diffs:
+        for (op, data) in diffs:
             if op != self.DIFF_INSERT:
                 text.append(data)
         return "".join(text)
@@ -1213,7 +1214,7 @@ class diff_match_patch:
         levenshtein = 0
         insertions = 0
         deletions = 0
-        for op, data in diffs:
+        for (op, data) in diffs:
             if op == self.DIFF_INSERT:
                 insertions += len(data)
             elif op == self.DIFF_DELETE:
@@ -1239,7 +1240,7 @@ class diff_match_patch:
           Delta text.
         """
         text = []
-        for op, data in diffs:
+        for (op, data) in diffs:
             if op == self.DIFF_INSERT:
                 # High ascii will raise UnicodeDecodeError.  Use Unicode instead.
                 data = data.encode("utf-8")
@@ -1727,7 +1728,7 @@ class diff_match_patch:
                     else:
                         self.diff_cleanupSemanticLossless(diffs)
                         index1 = 0
-                        for op, data in patch.diffs:
+                        for (op, data) in patch.diffs:
                             if op != self.DIFF_EQUAL:
                                 index2 = self.diff_xIndex(diffs, index1)
                             if op == self.DIFF_INSERT:  # Insertion
@@ -2026,7 +2027,7 @@ class patch_obj:
             coords2 = str(self.start2 + 1) + "," + str(self.length2)
         text = ["@@ -", coords1, " +", coords2, " @@\n"]
         # Escape the body of the patch with %xx notation.
-        for op, data in self.diffs:
+        for (op, data) in self.diffs:
             if op == diff_match_patch.DIFF_INSERT:
                 text.append("+")
             elif op == diff_match_patch.DIFF_DELETE:

--- a/xmldiff/diff_match_patch.py
+++ b/xmldiff/diff_match_patch.py
@@ -32,9 +32,17 @@ import urllib.parse
 
 
 class diff_object:
-    # The data structure representing a diff is an array of tuples:
-    # [(DIFF_DELETE, "Hello"), (DIFF_INSERT, "Goodbye"), (DIFF_EQUAL, " world.")]
-    # which means: delete "Hello", add "Goodbye" and keep " world."
+    """A class for a diff object, with a type identifier 
+    (integer, one of [-1, 0, 1, 2]) and at a text. In case of the 
+    REPLACE type (2), a secondary text (the replaced text) should 
+    also be given.
+
+    The class can be accessed like an iterable with obj[0] returning
+    the type identifier, obj[1] the main text and obj[2] the
+    secondary text. This is in order to be compatible with the previous
+    use of tuples for diff objects.
+    """
+
     DELETE = -1
     EQUAL = 0
     INSERT = 1
@@ -86,6 +94,9 @@ class diff_match_patch:
     def __init__(self, use_replace=False):
         """Inits a diff_match_patch object with default settings.
         Redefine these in your program to override the defaults.
+
+        The ``use_replace`` flag decides, if a replace tag (with the old text
+        as an attribute) should be used instead of one delete and one insert tag.
         """
 
         self.use_replace = use_replace
@@ -113,6 +124,11 @@ class diff_match_patch:
         # Multiple short patches (using native ints) are much faster than long ones.
         self.Match_MaxBits = 32
 
+
+    # The data structure representing a diff is the diff_object class, which can be 
+    # accessed as an iterable, for example:
+    # [DIFF_REPLACE, "Goodbye", "Hello"], [DIFF_EQUAL, " world."]
+    # which means: replace "Hello" with "Goodbye" and keep " world."
     DIFF_DELETE = -1
     DIFF_EQUAL = 0
     DIFF_INSERT = 1

--- a/xmldiff/diff_match_patch.py
+++ b/xmldiff/diff_match_patch.py
@@ -999,15 +999,15 @@ class diff_match_patch:
         text_insert = ""
         text_replace = ""
         while pointer < len(diffs):
-            if diffs[pointer][0] >= self.DIFF_INSERT:
+            if diffs[pointer][0] == self.DIFF_INSERT:
                 count_insert += 1
                 text_insert += diffs[pointer][1]
                 pointer += 1
-            elif diffs[pointer][0] <= self.DIFF_DELETE:
+            elif diffs[pointer][0] == self.DIFF_DELETE:
                 count_delete += 1
                 text_delete += diffs[pointer][1]
                 pointer += 1
-            elif diffs[pointer][0] <= self.DIFF_REPLACE:
+            elif diffs[pointer][0] == self.DIFF_REPLACE:
                 count_replace += 1
                 text_replace += diffs[pointer][1]
                 pointer += 1
@@ -1065,6 +1065,8 @@ class diff_match_patch:
                 text_delete = ""
                 text_insert = ""
                 text_replace = ""
+            else:
+                raise Exception(f"Unknown diff type {diffs[pointer][0]}")
 
         if diffs[-1][1] == "":
             diffs.pop()  # Remove the dummy entry at the end.

--- a/xmldiff/formatting.py
+++ b/xmldiff/formatting.py
@@ -313,13 +313,14 @@ class XMLFormatter(BaseFormatter):
     """
 
     def __init__(
-        self, normalize=WS_NONE, pretty_print=True, text_tags=(), formatting_tags=()
+        self, normalize=WS_NONE, pretty_print=True, text_tags=(), formatting_tags=(), use_replace=False
     ):
         # Mapping from placeholders -> structural content and vice versa.
         self.normalize = normalize
         self.pretty_print = pretty_print
         self.text_tags = text_tags
         self.formatting_tags = formatting_tags
+        self.use_replace = use_replace
         self.placeholderer = PlaceholderMaker(
             text_tags=text_tags, formatting_tags=formatting_tags
         )
@@ -594,7 +595,7 @@ class XMLFormatter(BaseFormatter):
             left_value = utils.cleanup_whitespace(left_value or "").strip()
             right_value = utils.cleanup_whitespace(right_value or "").strip()
 
-        text_diff = diff_match_patch()
+        text_diff = diff_match_patch(use_replace=self.use_replace)
         diff = text_diff.diff_main(left_value or "", right_value or "")
         text_diff.diff_cleanupSemantic(diff)
         diff = self._realign_placeholders(diff)

--- a/xmldiff/formatting.py
+++ b/xmldiff/formatting.py
@@ -541,38 +541,28 @@ class XMLFormatter(BaseFormatter):
         def _stack_pop():
             return stack.pop() if stack else (None, None)
 
-        for d in diff:
-            op = d[0] 
-            text = d[1]
-            if op == diff_match_patch.DIFF_REPLACE:
-                opt = d[2]
-            else:
-                opt = None
+        for op, text in diff:
             segments = self.placeholderer.split_string(text)
             for seg in segments:
                 if not seg:
                     continue
-                if op == diff_match_patch.DIFF_REPLACE:
-                    seg_diff = (op, seg, opt)
-                else:
-                    seg_diff = (op, seg)
                 # There is nothing to do for regular text.
                 if not self.placeholderer.is_placeholder(seg):
-                    new_diff.append(seg_diff)
+                    new_diff.append((op, seg))
                     continue
                 # Handle all structural replacement elements.
                 entry = self.placeholderer.placeholder2tag[seg]
                 if entry.ttype == T_SINGLE:
                     # There is nothing to do for singletons since they are
                     # fully self-contained.
-                    new_diff.append(seg_diff)
+                    new_diff.append((op, seg))
                     continue
                 elif entry.ttype == T_OPEN:
                     # Opening tags are added to the stack, so we know what
                     # needs to be closed when. We are assuming that tags are
                     # opened in the desired order.
-                    stack.append((op, entry, opt))
-                    new_diff.append(seg_diff)
+                    stack.append((op, entry))
+                    new_diff.append((op, seg))
                     continue
                 elif entry.ttype == T_CLOSE:
                     # Due to the nature of the text diffing algorithm, closing
@@ -582,7 +572,7 @@ class XMLFormatter(BaseFormatter):
                     # happen.
                     stack_op, stack_entry = _stack_pop()
                     while stack_entry is not None and stack_entry.close_ph != seg:
-                        new_diff.append((stack_op, stack_entry.close_ph, opt))
+                        new_diff.append((stack_op, stack_entry.close_ph))
                         stack_op, stack_entry = _stack_pop()
 
                     # Stephan: We have situations where the opening tag
@@ -597,7 +587,7 @@ class XMLFormatter(BaseFormatter):
                     # put in an assert
                     if stack_entry is not None:
                         assert stack_op <= op
-                        new_diff.append(seg_diff)
+                        new_diff.append((op, seg))
         return new_diff
 
     def _join_delete_insert(self, diffs):

--- a/xmldiff/formatting.py
+++ b/xmldiff/formatting.py
@@ -4,7 +4,7 @@ import re
 from collections import namedtuple
 from copy import deepcopy
 from lxml import etree
-from xmldiff.diff_match_patch import diff_match_patch
+from xmldiff.diff_match_patch import diff_match_patch, diff_object
 from xmldiff import utils
 
 
@@ -535,32 +535,33 @@ class XMLFormatter(BaseFormatter):
             return stack.pop() if stack else (None, None)
 
         for d in diff:
-            if len(d) == 2:
-                op, text = d
+            op = d[0]
+            text = d[1]
+            if op == diff_match_patch.DIFF_REPLACE:
+                opt = d[2]
             else:
-                op, text, opt = d
-                text = text + '|' + opt
+                opt = None
             segments = self.placeholderer.split_string(text)
             for seg in segments:
                 if not seg:
                     continue
                 # There is nothing to do for regular text.
                 if not self.placeholderer.is_placeholder(seg):
-                    new_diff.append((op, seg))
+                    new_diff.append(diff_object(op, seg, opt))
                     continue
                 # Handle all structural replacement elements.
                 entry = self.placeholderer.placeholder2tag[seg]
                 if entry.ttype == T_SINGLE:
                     # There is nothing to do for singletons since they are
                     # fully self-contained.
-                    new_diff.append((op, seg))
+                    new_diff.append(diff_object(op, seg, opt))
                     continue
                 elif entry.ttype == T_OPEN:
                     # Opening tags are added to the stack, so we know what
                     # needs to be closed when. We are assuming that tags are
                     # opened in the desired order.
-                    stack.append((op, entry))
-                    new_diff.append((op, seg))
+                    stack.append(diff_object(op, entry, opt))
+                    new_diff.append(diff_object(op, seg, opt))
                     continue
                 elif entry.ttype == T_CLOSE:
                     # Due to the nature of the text diffing algorithm, closing
@@ -570,7 +571,7 @@ class XMLFormatter(BaseFormatter):
                     # happen.
                     stack_op, stack_entry = _stack_pop()
                     while stack_entry is not None and stack_entry.close_ph != seg:
-                        new_diff.append((stack_op, stack_entry.close_ph))
+                        new_diff.append(diff_object(stack_op, stack_entry.close_ph, opt))
                         stack_op, stack_entry = _stack_pop()
 
                     # Stephan: We have situations where the opening tag
@@ -585,7 +586,7 @@ class XMLFormatter(BaseFormatter):
                     # put in an assert
                     if stack_entry is not None:
                         assert stack_op <= op
-                        new_diff.append((op, seg))
+                        new_diff.append(diff_object(op, seg, opt))
         return new_diff
 
     def _make_diff_tags(self, left_value, right_value, node, target=None):
@@ -605,11 +606,11 @@ class XMLFormatter(BaseFormatter):
             cur_child = node
 
         for d in diff:
-            op, text = d
-            if '|' in text:
-                _text = text.split('|')
-                text = _text[0]
-                old_text = _text[1]
+            op = d[0]
+            text = d[1]
+            if op == diff_match_patch.DIFF_REPLACE:
+                old_text = d[2]
+
             if op == 0:
                 if cur_child is None:
                     node.text = (node.text or "") + text

--- a/xmldiff/formatting.py
+++ b/xmldiff/formatting.py
@@ -540,8 +540,7 @@ class XMLFormatter(BaseFormatter):
         def _stack_pop():
             return stack.pop() if stack else (None, None)
 
-        for d in diff:
-            op, text = d
+        for op, text in diff:
             segments = self.placeholderer.split_string(text)
             for seg in segments:
                 if not seg:
@@ -642,7 +641,6 @@ class XMLFormatter(BaseFormatter):
                 else:
                     cur_child.tail = (cur_child.tail or "") + new_text
 
-
     def _handle_UpdateTextIn(self, action, tree):
         node = self._xpath(tree, action.node)
         if INSERT_NAME in node.attrib:
@@ -653,6 +651,7 @@ class XMLFormatter(BaseFormatter):
         left_value = node.text
         right_value = action.text
         node.text = None
+
         self._make_diff_tags(left_value, right_value, node)
 
         return node

--- a/xmldiff/formatting.py
+++ b/xmldiff/formatting.py
@@ -612,7 +612,7 @@ class XMLFormatter(BaseFormatter):
             if op == diff_match_patch.DIFF_REPLACE:
                 old_text = d[2]
 
-            if op == 0:
+            if op == diff_match_patch.DIFF_EQUAL:
                 if cur_child is None:
                     node.text = (node.text or "") + text
                 else:
@@ -620,11 +620,11 @@ class XMLFormatter(BaseFormatter):
                 continue
 
             attributes = {}
-            if op == -1:
+            if op == diff_match_patch.DIFF_DELETE:
                 action = "delete"
-            elif op == 1:
+            elif op == diff_match_patch.DIFF_INSERT:
                 action = "insert"
-            elif op == 2:
+            elif op == diff_match_patch.DIFF_REPLACE:
                 action = "replace"
                 attributes["old-text"] = old_text
 

--- a/xmldiff/formatting.py
+++ b/xmldiff/formatting.py
@@ -541,33 +541,28 @@ class XMLFormatter(BaseFormatter):
             return stack.pop() if stack else (None, None)
 
         for d in diff:
-            op = d[0]
-            text = d[1]
-            if op == diff_match_patch.DIFF_REPLACE:
-                opt = d[2]
-            else:
-                opt = None
+            op, text = d
             segments = self.placeholderer.split_string(text)
             for seg in segments:
                 if not seg:
                     continue
                 # There is nothing to do for regular text.
                 if not self.placeholderer.is_placeholder(seg):
-                    new_diff.append((op, seg, opt))
+                    new_diff.append((op, seg))
                     continue
                 # Handle all structural replacement elements.
                 entry = self.placeholderer.placeholder2tag[seg]
                 if entry.ttype == T_SINGLE:
                     # There is nothing to do for singletons since they are
                     # fully self-contained.
-                    new_diff.append((op, seg, opt))
+                    new_diff.append((op, seg))
                     continue
                 elif entry.ttype == T_OPEN:
                     # Opening tags are added to the stack, so we know what
                     # needs to be closed when. We are assuming that tags are
                     # opened in the desired order.
-                    stack.append((op, entry, opt))
-                    new_diff.append((op, seg, opt))
+                    stack.append((op, entry))
+                    new_diff.append((op, seg))
                     continue
                 elif entry.ttype == T_CLOSE:
                     # Due to the nature of the text diffing algorithm, closing
@@ -577,7 +572,7 @@ class XMLFormatter(BaseFormatter):
                     # happen.
                     stack_op, stack_entry = _stack_pop()
                     while stack_entry is not None and stack_entry.close_ph != seg:
-                        new_diff.append((stack_op, stack_entry.close_ph, opt))
+                        new_diff.append((stack_op, stack_entry.close_ph))
                         stack_op, stack_entry = _stack_pop()
 
                     # Stephan: We have situations where the opening tag
@@ -592,7 +587,7 @@ class XMLFormatter(BaseFormatter):
                     # put in an assert
                     if stack_entry is not None:
                         assert stack_op <= op
-                        new_diff.append((op, seg, opt))
+                        new_diff.append((op, seg))
         return new_diff
 
     def _make_diff_tags(self, left_value, right_value, node, target=None):

--- a/xmldiff/formatting.py
+++ b/xmldiff/formatting.py
@@ -601,7 +601,7 @@ class XMLFormatter(BaseFormatter):
             next_op, next_text = diffs[i+1]
             # insert, then delete
             if op==diff_match_patch.DIFF_INSERT and next_op==diff_match_patch.DIFF_DELETE:
-                new_diffs.apped((diff_match_patch.DIFF_REPLACE, text, next_text))
+                new_diffs.append((diff_match_patch.DIFF_REPLACE, text, next_text))
                 skip_next = True # also skip upcoming delete
             # delete, then insert
             elif next_op==diff_match_patch.DIFF_INSERT and op==diff_match_patch.DIFF_DELETE:

--- a/xmldiff/formatting.py
+++ b/xmldiff/formatting.py
@@ -310,6 +310,9 @@ class XMLFormatter(BaseFormatter):
     WS_TEXT normalizes only inside text_tags, WS_TAGS will remove ignorable
     whitespace between tags, WS_BOTH do both, and WS_NONE will preserve
     all whitespace.
+
+    The ``use_replace`` flag decides, if a replace tag (with the old text
+    as an attribute) should be used instead of one delete and one insert tag.
     """
 
     def __init__(

--- a/xmldiff/formatting.py
+++ b/xmldiff/formatting.py
@@ -234,7 +234,7 @@ class PlaceholderMaker:
     def undo_tree(self, tree):
         self.undo_element(tree)
 
-    def mark_diff(self, ph, action, attributes={}):
+    def mark_diff(self, ph, action, attributes=None):
         entry = self.placeholder2tag[ph]
         if entry.ttype == T_CLOSE:
             # Close tag, nothing to mark
@@ -248,15 +248,16 @@ class PlaceholderMaker:
             # Formatting element, add a diff attribute
             action += "-formatting"
         elem.attrib[f"{{{DIFF_NS}}}{action}"] = ""
-        for attrib, value in attributes.items():
-            elem.attrib[attrib] = value
+        if attributes is not None:
+            for attrib, value in attributes.items():
+                elem.attrib[attrib] = value
 
         # And make a new placeholder for this new entry:
         return self.get_placeholder(elem, entry.ttype, entry.close_ph)
 
     def wrap_diff(self, text, action, attributes=None):
         open_ph, close_ph = self.diff_tags[action]
-        if attributes is not None:
+        if attributes is not None and len(attributes) > 0:
             entry = self.placeholder2tag[open_ph]
             elem = entry.element
             elem = deepcopy(elem)

--- a/xmldiff/formatting.py
+++ b/xmldiff/formatting.py
@@ -609,6 +609,9 @@ class XMLFormatter(BaseFormatter):
                 skip_next = True # also skip upcoming insert
             else:
                 new_diffs.append(diffs[i])
+        # append last diff, if it shouldn't be skipped
+        if not skip_next:
+            new_diffs.append(diffs[-1])
         return new_diffs
 
     def _make_diff_tags(self, left_value, right_value, node, target=None):

--- a/xmldiff/formatting.py
+++ b/xmldiff/formatting.py
@@ -541,28 +541,38 @@ class XMLFormatter(BaseFormatter):
         def _stack_pop():
             return stack.pop() if stack else (None, None)
 
-        for op, text in diff:
+        for d in diff:
+            op = d[0] 
+            text = d[1]
+            if op == diff_match_patch.DIFF_REPLACE:
+                opt = d[2]
+            else:
+                opt = None
             segments = self.placeholderer.split_string(text)
             for seg in segments:
                 if not seg:
                     continue
+                if op == diff_match_patch.DIFF_REPLACE:
+                    seg_diff = (op, seg, opt)
+                else:
+                    seg_diff = (op, seg)
                 # There is nothing to do for regular text.
                 if not self.placeholderer.is_placeholder(seg):
-                    new_diff.append((op, seg))
+                    new_diff.append(seg_diff)
                     continue
                 # Handle all structural replacement elements.
                 entry = self.placeholderer.placeholder2tag[seg]
                 if entry.ttype == T_SINGLE:
                     # There is nothing to do for singletons since they are
                     # fully self-contained.
-                    new_diff.append((op, seg))
+                    new_diff.append(seg_diff)
                     continue
                 elif entry.ttype == T_OPEN:
                     # Opening tags are added to the stack, so we know what
                     # needs to be closed when. We are assuming that tags are
                     # opened in the desired order.
-                    stack.append((op, entry))
-                    new_diff.append((op, seg))
+                    stack.append((op, entry, opt))
+                    new_diff.append(seg_diff)
                     continue
                 elif entry.ttype == T_CLOSE:
                     # Due to the nature of the text diffing algorithm, closing
@@ -572,7 +582,7 @@ class XMLFormatter(BaseFormatter):
                     # happen.
                     stack_op, stack_entry = _stack_pop()
                     while stack_entry is not None and stack_entry.close_ph != seg:
-                        new_diff.append((stack_op, stack_entry.close_ph))
+                        new_diff.append((stack_op, stack_entry.close_ph, opt))
                         stack_op, stack_entry = _stack_pop()
 
                     # Stephan: We have situations where the opening tag
@@ -587,7 +597,7 @@ class XMLFormatter(BaseFormatter):
                     # put in an assert
                     if stack_entry is not None:
                         assert stack_op <= op
-                        new_diff.append((op, seg))
+                        new_diff.append(seg_diff)
         return new_diff
 
     def _make_diff_tags(self, left_value, right_value, node, target=None):

--- a/xmldiff/formatting.py
+++ b/xmldiff/formatting.py
@@ -4,7 +4,7 @@ import re
 from collections import namedtuple
 from copy import deepcopy
 from lxml import etree
-from xmldiff.diff_match_patch import diff_match_patch, diff_object
+from xmldiff.diff_match_patch import diff_match_patch
 from xmldiff import utils
 
 
@@ -551,21 +551,21 @@ class XMLFormatter(BaseFormatter):
                     continue
                 # There is nothing to do for regular text.
                 if not self.placeholderer.is_placeholder(seg):
-                    new_diff.append(diff_object(op, seg, opt))
+                    new_diff.append((op, seg, opt))
                     continue
                 # Handle all structural replacement elements.
                 entry = self.placeholderer.placeholder2tag[seg]
                 if entry.ttype == T_SINGLE:
                     # There is nothing to do for singletons since they are
                     # fully self-contained.
-                    new_diff.append(diff_object(op, seg, opt))
+                    new_diff.append((op, seg, opt))
                     continue
                 elif entry.ttype == T_OPEN:
                     # Opening tags are added to the stack, so we know what
                     # needs to be closed when. We are assuming that tags are
                     # opened in the desired order.
-                    stack.append(diff_object(op, entry, opt))
-                    new_diff.append(diff_object(op, seg, opt))
+                    stack.append((op, entry, opt))
+                    new_diff.append((op, seg, opt))
                     continue
                 elif entry.ttype == T_CLOSE:
                     # Due to the nature of the text diffing algorithm, closing
@@ -575,7 +575,7 @@ class XMLFormatter(BaseFormatter):
                     # happen.
                     stack_op, stack_entry = _stack_pop()
                     while stack_entry is not None and stack_entry.close_ph != seg:
-                        new_diff.append(diff_object(stack_op, stack_entry.close_ph, opt))
+                        new_diff.append((stack_op, stack_entry.close_ph, opt))
                         stack_op, stack_entry = _stack_pop()
 
                     # Stephan: We have situations where the opening tag
@@ -590,7 +590,7 @@ class XMLFormatter(BaseFormatter):
                     # put in an assert
                     if stack_entry is not None:
                         assert stack_op <= op
-                        new_diff.append(diff_object(op, seg, opt))
+                        new_diff.append((op, seg, opt))
         return new_diff
 
     def _make_diff_tags(self, left_value, right_value, node, target=None):


### PR DESCRIPTION
Add option to XMLFormatter to use replace tags, see issue #112 

- in _make_diff_tags after diffing, neighboring delete/insert diffs are joined to a replace tag
- the deleted text is added as an attribute ("old-text")
- the inserted text is the element's text
- In the test cases, the hardcoded placeholders in other tests needed to be updated (added an offset of 2, as there are 2 more default tags)