### PR TITLE
Link failed, update the reference link to a valid one

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,5 +90,5 @@ Contributors
 
  * Jacek Chałupka, krunchfrompoland@gmail.com
 
-The diff algorithm is based on "`Change Detection in Hierarchically Structured Information <http://ilpubs.stanford.edu/115/1/1995-46.pdf>`_",
+The diff algorithm is based on "`Change Detection in Hierarchically Structured Information <http://infolab.stanford.edu/c3/papers/html/tdiff3-8/tdiff3-8.html>`_",
 and the text diff is using Google's ``diff_match_patch`` algorithm.


### PR DESCRIPTION
The old reference link is no longer available.