### PR TITLE
setuptools is not needed at runtime

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,9 @@ include_package_data = True
 packages = find:
 package_dir =
     = .
-install_requires =
+setup_requires =
     setuptools
+install_requires =
     lxml>=3.1.0
 
 [options.packages.find]


### PR DESCRIPTION
This patch was applied in Debian

(I mean only the second part...)

https://salsa.debian.org/debian/xmldiff/-/blob/debian/master/debian/patches/version.patch?ref_type=heads