### PR TITLE
Use a regexp to parse the diff files

### DIFF
--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -253,3 +253,13 @@ class ParserTests(unittest.TestCase):
             expected = f.read()
         # lxml.etree.parse() will strip ending whitespace
         self.assertEqual(result, expected.rstrip())
+
+    def test_parse_commas(self):
+        parser = DiffParser()
+
+        # There should be able to be a comma in the value
+        actions = list(parser.parse('[update-text-after, /root/anode[1], "foo,bar"]'))
+        self.assertEqual(
+            actions,
+            [UpdateTextAfter(node="/root/anode[1]", text="foo,bar", oldtext=None)],
+        )

--- a/xmldiff/patch.py
+++ b/xmldiff/patch.py
@@ -1,8 +1,12 @@
+import re
+
 from copy import deepcopy
-from csv import reader
 from json import loads
 from lxml import etree
 from xmldiff import actions
+
+
+DIFF_SPLIT = re.compile('(?:"[^"]*"|[^, ])+|(?<![^,])(?![^,])')
 
 
 class Patcher:
@@ -119,7 +123,7 @@ class DiffParser:
         line = line[1:-1]
         # Split the line on commas (ignoring commas in quoted strings) and
         # strip extraneous spaces. The first is the action, the rest params.
-        parts = [x.strip() for x in next(reader([line]))]
+        parts = DIFF_SPLIT.findall(line)
         action = parts[0]
         params = parts[1:]
         # Get the method, and return the result of calling it


### PR DESCRIPTION
Python csv can't handle two-character separators, and we use comma<space>.