### PR TITLE
fix(matching): Prevent double-match

### DIFF
--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -967,6 +967,24 @@ class BestFastMatchTests(unittest.TestCase):
         )
 
 
+    def test_best_match_no_double_match(self):
+        left = '''\
+<a>
+    <p>x<b>xy</b></p>
+</a>
+'''
+        right = '''\
+<a>
+    <p>x</p>
+</a>
+'''
+        matches = self._match(left, right, best_match=True)
+        # All matched paths should be exactly equal,
+        # and /a/p/b should not be matched with anything
+        for (lpath, rpath) in matches:
+            self.assertEqual(lpath, rpath)
+        self.assertNotIn("/a/p/b", [m[0] for m in matches])
+
 class UpdateNodeTests(unittest.TestCase):
     """Testing only the update phase of the diffing"""
 

--- a/xmldiff/diff.py
+++ b/xmldiff/diff.py
@@ -155,10 +155,16 @@ class Differ:
                     unmatched_lnodes.append((lnode, match_node, max_match))
                     # unmatched_lnodes.append(lnode)
 
+            # Sort by descending match quality so better matches get
+            # priority, and remove matched rnodes to prevent multiple
+            # left nodes from matching the same right node.
             lnodes = []
-            for lnode, rnode, max_match in unmatched_lnodes:
+            for lnode, rnode, max_match in sorted(
+                unmatched_lnodes, key=lambda x: -x[2]
+            ):
                 if max_match >= self.F and rnode in rnodes:
                     self.append_match(lnode, rnode, max_match)
+                    rnodes.remove(rnode)
                 else:
                     lnodes.append(lnode)
 


### PR DESCRIPTION
Without this fix, `a/p/b` from the left tree gets matched to `a/p` from the right tree in the added test.