### PR TITLE
improvement(utils): Use deque instead of list for BFS

### DIFF
--- a/xmldiff/utils.py
+++ b/xmldiff/utils.py
@@ -1,5 +1,6 @@
 import re
 
+from collections import deque
 from operator import eq
 
 # This namespace is reserved for lxml internal use, which only
@@ -23,10 +24,10 @@ def reverse_post_order_traverse(node):
 
 def breadth_first_traverse(node):
     # First yield the root node
-    queue = [node]
+    queue = deque([node])
 
     while queue:
-        item = queue.pop(0)
+        item = queue.popleft()
         yield item
         queue.extend(item.getchildren())
 


### PR DESCRIPTION
`list.pop(0)` has linear complexity (in the number of list members), so the previous BFS implementation had a quadratic complexity.

I used this program to measure the difference:
```python
import time
from lxml import etree
from xmldiff import main as xmldiff

def make_xml(breadth, depth, tweak_last=False):
    """Generate an XML string with `breadth` children per node, `depth` levels."""
    lines = ['<root>']

    def build(level, path):
        if level >= depth:
            return
        for i in range(breadth):
            tag = f"n{i}"
            attr = f' v="{path}_{i}"'
            # Tweak the very last leaf to force a diff
            if tweak_last and level == depth - 1 and i == breadth - 1:
                attr += ' changed="true"'
            lines.append(f'<{tag}{attr}>')
            build(level + 1, f"{path}_{i}")
            lines.append(f'</{tag}>')

    build(0, "r")
    lines.append('</root>')
    return etree.fromstring('\n'.join(lines))

def main():
    breadth = 5
    depth = 5

    left = make_xml(breadth, depth)
    right = make_xml(breadth, depth, tweak_last=True)

    start = time.perf_counter()
    xmldiff.diff_trees(left, right)
    elapsed = time.perf_counter() - start

    # Count nodes for reference
    total = sum(breadth ** i for i in range(depth + 1))
    print(f"nodes={total}  time={elapsed:.4f}s")

if __name__ == "__main__":
    main()
```

The current version was approximately 300ms faster than master.